### PR TITLE
magento global error reporting enabled.

### DIFF
--- a/guides/m1x/magefordev/mage-for-dev-5.html
+++ b/guides/m1x/magefordev/mage-for-dev-5.html
@@ -189,6 +189,7 @@ CREATE TABLE `blog_posts` (
 </pre>
 
 <p>and reload your page.  You should see an exception that looks something like this (be sure you've turned on <a href="http://c3-stage.magedevteam.com/wiki/3_-_store_setup_and_management/configure_magento_error_page#display_errors_on_the_same_page_developer_mode">developer mode</a>).</p>
+<p>OR just edit the .htaccess file and add the `SetEnv MAGE_IS_DEVELOPER_MODE "true"` . Do not set this environment in production.</p>
 
 <pre>
 include(Magentotutorial/Weblog/Model/Blogpost.php) [function.include]: failed to open stream: No such file or directory


### PR DESCRIPTION
Magento environment set up for the global error reporting and displaying locally errors for the developer

`SetEnv MAGE_IS_DEVELOPER_MODE "true"`
